### PR TITLE
Update DocumentationBuilder target to work with Swift 5

### DIFF
--- a/.jazzy.json
+++ b/.jazzy.json
@@ -1,8 +1,8 @@
 {
     "author": "Plausible Labs",
-    "author_url": "https://opensource.plausible.coop/src/projects/SWC/repos/plrelational",
+    "author_url": "https://github.com/plausiblelabs/plrelational",
     "module": "PLRelational",
-    "readme": "README.md",
+    "readme": "README.markdown",
     "theme": "fullwidth",
 
     "documentation": "Docs/*.md",

--- a/PLRelational.xcodeproj/project.pbxproj
+++ b/PLRelational.xcodeproj/project.pbxproj
@@ -5589,7 +5589,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -5601,7 +5601,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/PLRelational.xcodeproj/xcshareddata/xcschemes/DocumentationBuilder.xcscheme
+++ b/PLRelational.xcodeproj/xcshareddata/xcschemes/DocumentationBuilder.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1110"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C27511131F20DFE3009DB9CC"
+               BuildableName = "DocumentationBuilder"
+               BlueprintName = "DocumentationBuilder"
+               ReferencedContainer = "container:PLRelational.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C27511131F20DFE3009DB9CC"
+            BuildableName = "DocumentationBuilder"
+            BlueprintName = "DocumentationBuilder"
+            ReferencedContainer = "container:PLRelational.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "PLRelational-macOS"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "PLRelationalBinding-macOS"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C27511131F20DFE3009DB9CC"
+            BuildableName = "DocumentationBuilder"
+            BlueprintName = "DocumentationBuilder"
+            ReferencedContainer = "container:PLRelational.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Also, include a shared scheme for DocumentationBuilder that runs it for the PLRelational-macOS and PLRelationalBinding-macOS targets by default.
